### PR TITLE
Fix jQuery URL

### DIFF
--- a/askbotopenmooc/askbot-openmooc-themes/mooc/templates/meta/bottom_scripts.html
+++ b/askbotopenmooc/askbot-openmooc-themes/mooc/templates/meta/bottom_scripts.html
@@ -25,7 +25,7 @@
     {% if settings.DEBUG %}
         src="{{"/js/jquery-1.7.2.min.js"|media}}"
     {% else %}
-        src="///ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js"
+        src="//ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js"
     {% endif %}
 ></script>
 <!-- History.js -->


### PR DESCRIPTION
When not in debug mode, jQuery URL has one unnecessary slash that makes some browsers (e.g. Internet Explorer) not to load jQuery
